### PR TITLE
Add specialized MadamLive scraper

### DIFF
--- a/.github/workflows/scrape_madamlive.yml
+++ b/.github/workflows/scrape_madamlive.yml
@@ -1,0 +1,26 @@
+name: Scrape MadamLive
+
+on:
+  workflow_dispatch:
+  schedule:
+      - cron: '0 */2 * * *'
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run scraper
+        env:
+          GSHEET_JSON: ${{ secrets.GSHEET_JSON }}
+          SPREADSHEET_ID: ${{ secrets.SPREADSHEET_ID }}
+          SHEET_NAME: ${{ secrets.SHEET_NAME }}
+          LISTING_URL: ${{ secrets.LISTING_URL }}
+        run: python scrape_madamlive.py

--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ This repository contains a scraper that extracts profile data from a listing pag
    export SPREADSHEET_ID=your_spreadsheet_id
    export SHEET_NAME=live
    ```
-4. Set the URL of the listing page to scrape:
+4. Set the URL of the listing page to scrape. The madamlive scraper uses
+   `madam` as the default sheet name, so override it if necessary:
    ```bash
    export LISTING_URL=https://example.com/listing
+   export SHEET_NAME=madam
    ```
 
 ## Running
@@ -28,14 +30,15 @@ This repository contains a scraper that extracts profile data from a listing pag
 Run the scraper with Python:
 
 ```bash
-python update_sheet.py
+python update_sheet.py             # generic scraper
+python scrape_madamlive.py         # scraper for madamlive.tv
 ```
 
-The script reads the listing page, fetches each profile's detail page, and appends any new entries to the specified Google Sheet.
+Both scripts read a listing page, fetch each profile's detail page, and append new entries to the configured Google Sheet.
 
 ## GitHub Actions
 
-A workflow in `.github/workflows/update_sheet.yml` can run the scraper on a schedule or on demand. To use it, add the following secrets to your repository settings:
+A workflow in `.github/workflows/update_sheet.yml` can run the generic scraper, while `.github/workflows/scrape_madamlive.yml` runs the madamlive-specific one. To use them, add the following secrets to your repository settings:
 
 - `GSHEET_JSON` – base64-encoded service account JSON
 - `SPREADSHEET_ID` – ID of the spreadsheet

--- a/scrape_madamlive.py
+++ b/scrape_madamlive.py
@@ -1,0 +1,160 @@
+import os
+import json
+import base64
+import re
+from urllib.parse import urljoin
+import time
+
+import requests
+from bs4 import BeautifulSoup
+import gspread
+
+SPREADSHEET_ID = os.environ.get("SPREADSHEET_ID", "YOUR_SPREADSHEET_ID")
+SHEET_NAME = os.environ.get("SHEET_NAME", "madam")
+LISTING_URL = os.environ.get("LISTING_URL", "https://madamlive.tv/listing")
+
+
+def get_gspread_client():
+    b64 = os.environ.get("GSHEET_JSON")
+    if not b64:
+        raise ValueError("GSHEET_JSON not set")
+    data = json.loads(base64.b64decode(b64).decode("utf-8"))
+    return gspread.service_account_from_dict(data)
+
+
+def open_sheet():
+    gc = get_gspread_client()
+    sh = gc.open_by_key(SPREADSHEET_ID)
+    return sh.worksheet(SHEET_NAME)
+
+
+def fetch_html(url):
+    headers = {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
+    }
+    try:
+        resp = requests.get(url, headers=headers, timeout=20)
+        resp.raise_for_status()
+        return resp.text
+    except requests.exceptions.RequestException as e:
+        print(f"Error fetching {url}: {e}")
+        return None
+
+
+def parse_listing(html, base_url):
+    """Parse the listing page and return basic profile info."""
+    soup = BeautifulSoup(html, "html.parser")
+    entries = []
+
+    for dl in soup.select("dl.onlinegirl-dl-big"):
+        name_a = dl.select_one("h3 a")
+        img_tag = dl.select_one("dd.onlinegirl-dd-img-big img")
+        if not name_a:
+            continue
+        comment_tag = dl.select_one("span.onlinegirl-dd-comment-span-big")
+        if not (name_a and img_tag):
+            continue
+
+        name = name_a.get_text(strip=True)
+        url = name_a.get("href", "")
+        if url and not url.startswith("http"):
+            url = urljoin(base_url, url)
+        image = urljoin(base_url, img_tag.get("src", ""))
+        comment = comment_tag.get_text(strip=True) if comment_tag else ""
+
+        entries.append({
+            "name": name,
+            "image": image,
+            "url": url,
+            "comment": comment,
+        })
+
+    return entries
+
+
+def parse_detail(html):
+    soup = BeautifulSoup(html, "html.parser")
+
+    def get_dd(label):
+        dt = soup.find("dt", string=re.compile(label))
+        if not dt:
+            return ""
+        dd = dt.find_next("dd")
+        return dd.get_text(strip=True) if dd else ""
+
+    def text_by_class(cls):
+        tag = soup.select_one(f"dd.{cls}")
+        return tag.get_text(strip=True) if tag else ""
+
+    detail = {
+        "age": text_by_class("p-age") or get_dd("年齢"),
+        "height": text_by_class("p-height") or get_dd("身長"),
+        "cup": text_by_class("p-cup") or text_by_class("p-bwh") or get_dd("(カップ数|スリーサイズ)"),
+        "face": text_by_class("p-face") or get_dd("顔出し"),
+        "toy": text_by_class("p-toy") or get_dd("おもちゃ"),
+        "appear": text_by_class("p-appear") or get_dd("出没時間"),
+        "style": text_by_class("p-style") or get_dd("(スタイル|体型)"),
+        "job": text_by_class("p-job") or get_dd("職業"),
+        "hobby": text_by_class("p-hobby") or text_by_class("p-boom") or get_dd("(趣味|マイブーム)"),
+        "favor": text_by_class("p-favor") or get_dd("(好みのタイプ|好きな男性のタイプ)"),
+        "seikantai": text_by_class("p-seikantai") or get_dd("性感帯"),
+        "genre": text_by_class("p-genre") or get_dd("ジャンル"),
+    }
+
+    if not detail["genre"]:
+        genres = [div.get_text(strip=True) for div in soup.select("dd.genre-list div.genre-div")]
+        detail["genre"] = ",".join(genres)
+
+    return detail
+
+
+def main():
+    ws = open_sheet()
+    existing = set(ws.col_values(3))  # column C for URL
+
+    print(f"Fetching listing page: {LISTING_URL}")
+    listing_html = fetch_html(LISTING_URL)
+    if not listing_html:
+        print("Failed to get listing page. Aborting.")
+        return
+
+    items = parse_listing(listing_html, LISTING_URL)
+    print(f"Found {len(items)} items on the listing page.")
+
+    for item in items:
+        if item["url"] in existing:
+            continue
+
+        print(f"Fetching detail page: {item['url']}")
+        detail_html = fetch_html(item["url"])
+        if not detail_html:
+            print(f"Skipping {item['name']} because detail page could not be fetched.")
+            continue
+
+        detail = parse_detail(detail_html)
+        row = [
+            item["name"],
+            item["image"],
+            item["url"],
+            item["comment"],
+            detail.get("age", ""),
+            detail.get("height", ""),
+            detail.get("cup", ""),
+            detail.get("face", ""),
+            detail.get("toy", ""),
+            detail.get("appear", ""),
+            detail.get("style", ""),
+            detail.get("job", ""),
+            detail.get("hobby", ""),
+            detail.get("favor", ""),
+            detail.get("seikantai", ""),
+            detail.get("genre", ""),
+        ]
+        ws.append_row(row)
+        print(f"Added: {item['name']} - {item['url']}")
+
+        time.sleep(1.5)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document `madam` sheet name in README
- add GitHub Actions workflow for madamlive scraper
- implement `scrape_madamlive.py` to gather listing and profile data
- improve madamlive scraper parsing

## Testing
- `python -m py_compile scrape_madamlive.py update_sheet.py`


------
https://chatgpt.com/codex/tasks/task_e_684cf443bb248323b64a6afe07503ea8